### PR TITLE
Enhance system user serialize process

### DIFF
--- a/src/main/java/cloud/fogbow/common/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/common/constants/Messages.java
@@ -21,6 +21,7 @@ public class Messages {
         public static final String INVALID_PUBLIC_KEY = "Invalid public key fetched from external server.";
         public static final String INVALID_TOKEN = "Invalid token value.";
         public static final String INVALID_URL = "Invalid url: %s.";
+        public static final String MAXIMUM_SIZE_EXCEEDED = "The serialized object is larger than allowed.";
         public static final String NEITHER_BODY_OR_HEADERS_CAN_BE_NULL = "Neither body or headers can be null";
         public static final String NO_AVAILABLE_RESOURCES = "No available resources.";
         public static final String NO_USER_CREDENTIALS = "No user credentials given.";
@@ -31,7 +32,6 @@ public class Messages {
         public static final String UNAVAILABLE_PROVIDER = "Provider is not available.";
         public static final String UNEXPECTED = "Unexpected error.";
         public static final String WRONG_SYNTAX_FOR_ENDPOINT_S = "Wrong syntax for endpoint %s.";
-        public static final String MAXIMUM_USER_SIZE_EXCEEDED = "The system user data's size is larger than allowed";
     }
 
     public static class Fatal {

--- a/src/main/java/cloud/fogbow/common/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/common/constants/Messages.java
@@ -31,6 +31,7 @@ public class Messages {
         public static final String UNAVAILABLE_PROVIDER = "Provider is not available.";
         public static final String UNEXPECTED = "Unexpected error.";
         public static final String WRONG_SYNTAX_FOR_ENDPOINT_S = "Wrong syntax for endpoint %s.";
+        public static final String MAXIMUM_USER_SIZE_EXCEEDED = "The system user data's size is larger than allowed";
     }
 
     public static class Fatal {

--- a/src/main/java/cloud/fogbow/common/util/SerializableEntity.java
+++ b/src/main/java/cloud/fogbow/common/util/SerializableEntity.java
@@ -1,0 +1,16 @@
+package cloud.fogbow.common.util;
+
+public class SerializableEntity<T> {
+
+    private String className;
+    private String payload;
+
+    public SerializableEntity(T instanceToSerialize) {
+        this.className = instanceToSerialize.getClass().getName();
+        this.payload = GsonHolder.getInstance().toJson(instanceToSerialize);
+    }
+
+    public T getSerializedEntity() throws ClassNotFoundException {
+        return (T) GsonHolder.getInstance().fromJson(this.payload, Class.forName(this.className));
+    }
+}

--- a/src/main/java/cloud/fogbow/common/util/SerializableEntity.java
+++ b/src/main/java/cloud/fogbow/common/util/SerializableEntity.java
@@ -13,4 +13,9 @@ public class SerializableEntity<T> {
     public T getSerializedEntity() throws ClassNotFoundException {
         return (T) GsonHolder.getInstance().fromJson(this.payload, Class.forName(this.className));
     }
+
+    @Override
+    public String toString() {
+        return GsonHolder.getInstance().toJson(this, SerializableEntity.class);
+    }
 }

--- a/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
+++ b/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
@@ -5,9 +5,17 @@ import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.SystemUser;
 
 public class SystemUserUtil {
-    public static String serialize(SystemUser systemUser) {
+
+    public static final int SERIALIZED_SYSTEM_USER_MAX_SIZE = 1024;
+
+    public static String serialize(SystemUser systemUser) throws UnexpectedException{
         SerializableEntity<SystemUser> serializableSystemUser = new SerializableEntity<SystemUser>(systemUser);
         String serializedSystemUser = GsonHolder.getInstance().toJson(serializableSystemUser);
+
+        if(serializedSystemUser.length() > SystemUserUtil.SERIALIZED_SYSTEM_USER_MAX_SIZE) {
+            throw new UnexpectedException(Messages.Exception.MAXIMUM_USER_SIZE_EXCEEDED);
+        }
+
         return serializedSystemUser;
     }
     

--- a/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
+++ b/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
@@ -1,25 +1,21 @@
 package cloud.fogbow.common.util;
 
-import cloud.fogbow.common.constants.FogbowConstants;
 import cloud.fogbow.common.constants.Messages;
 import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.SystemUser;
-import com.google.gson.reflect.TypeToken;
-import org.apache.commons.lang.StringUtils;
 
 public class SystemUserUtil {
     public static String serialize(SystemUser systemUser) {
-        String className = systemUser.getClass().getName();
-        String serializedSystemUser = className + FogbowConstants.CLASS_NAME_SEPARATOR + GsonHolder.getInstance().toJson(systemUser);
+        SerializableEntity<SystemUser> serializableSystemUser = new SerializableEntity<SystemUser>(systemUser);
+        String serializedSystemUser = GsonHolder.getInstance().toJson(serializableSystemUser);
         return serializedSystemUser;
     }
     
     public static SystemUser deserialize(String serializedSystemUser) throws UnexpectedException {
-        String fields[] = StringUtils.splitByWholeSeparator(serializedSystemUser, FogbowConstants.CLASS_NAME_SEPARATOR);
         try {
-            Class<?> clazz = Class.forName(fields[0]);
-            TypeToken<?> typeToken = TypeToken.get(clazz);
-            return GsonHolder.getInstance().fromJson(fields[1], typeToken.getType());
+            SerializableEntity<SystemUser> serializableEntity = GsonHolder.getInstance().fromJson(serializedSystemUser, SerializableEntity.class);
+            SystemUser systemUser = serializableEntity.getSerializedEntity();
+            return systemUser;
         } catch (ClassNotFoundException e) {
             throw new UnexpectedException(Messages.Exception.UNABLE_TO_FIND_SYSTEM_USER_CLASS_S);
         }

--- a/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
+++ b/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
@@ -10,7 +10,7 @@ public class SystemUserUtil {
 
     public static String serialize(SystemUser systemUser) throws UnexpectedException{
         SerializableEntity<SystemUser> serializableSystemUser = new SerializableEntity<SystemUser>(systemUser);
-        String serializedSystemUser = GsonHolder.getInstance().toJson(serializableSystemUser);
+        String serializedSystemUser = serializableSystemUser.toString();
 
         if(serializedSystemUser.length() > SystemUserUtil.SERIALIZED_SYSTEM_USER_MAX_SIZE) {
             throw new UnexpectedException(Messages.Exception.MAXIMUM_USER_SIZE_EXCEEDED);

--- a/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
+++ b/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
@@ -6,7 +6,7 @@ import cloud.fogbow.common.models.SystemUser;
 
 public class SystemUserUtil {
 
-    public static final int SERIALIZED_SYSTEM_USER_MAX_SIZE = 1024;
+    public static final int SERIALIZED_SYSTEM_USER_MAX_SIZE = 2048;
 
     public static String serialize(SystemUser systemUser) throws UnexpectedException{
         SerializableEntity<SystemUser> serializableSystemUser = new SerializableEntity<SystemUser>(systemUser);

--- a/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
+++ b/src/main/java/cloud/fogbow/common/util/SystemUserUtil.java
@@ -13,7 +13,7 @@ public class SystemUserUtil {
         String serializedSystemUser = serializableSystemUser.toString();
 
         if(serializedSystemUser.length() > SystemUserUtil.SERIALIZED_SYSTEM_USER_MAX_SIZE) {
-            throw new UnexpectedException(Messages.Exception.MAXIMUM_USER_SIZE_EXCEEDED);
+            throw new UnexpectedException(Messages.Exception.MAXIMUM_SIZE_EXCEEDED);
         }
 
         return serializedSystemUser;


### PR DESCRIPTION
There was a problem related to the string generated by Gson from SystemUser. If it was larger than allowed by the database the order wouldn't be saved, and even worse, it could be too late for any fix.
To solve that problem, I've implemented a generic class called SerializableEntity and in the SystemUserUtil.serialize() I've added a verification that checks if the string is larger than allowed. If so, an exception is raised in the authentication process, before trying to save the order.