### PR TITLE
Throw a more readable exception for db integrity violation

### DIFF
--- a/src/main/java/cloud/fogbow/common/constants/Messages.java
+++ b/src/main/java/cloud/fogbow/common/constants/Messages.java
@@ -32,6 +32,7 @@ public class Messages {
         public static final String UNAVAILABLE_PROVIDER = "Provider is not available.";
         public static final String UNEXPECTED = "Unexpected error.";
         public static final String WRONG_SYNTAX_FOR_ENDPOINT_S = "Wrong syntax for endpoint %s.";
+        public static final String DATABASE_INTEGRITY_VIOLATED = "The database may be incompatible or corrupted.";
     }
 
     public static class Fatal {

--- a/src/main/java/cloud/fogbow/common/datastore/FogbowDatabaseService.java
+++ b/src/main/java/cloud/fogbow/common/datastore/FogbowDatabaseService.java
@@ -1,6 +1,8 @@
 package cloud.fogbow.common.datastore;
 
+import cloud.fogbow.common.constants.Messages;
 import cloud.fogbow.common.exceptions.UnexpectedException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.TransactionSystemException;
 
@@ -23,10 +25,18 @@ public class FogbowDatabaseService<T> {
                 StorableObjectTruncateHelper<S> truncateHelper = new StorableObjectTruncateHelper<>(o.getClass());
                 S truncated = truncateHelper.truncate(o);
 
-                repository.save(truncated);
+                saveTruncatedObject(truncated, repository);
             } else {
                 throw new UnexpectedException("", e);
             }
+        }
+    }
+
+    private void saveTruncatedObject(T truncatedObject, JpaRepository<T, ?> repository) throws UnexpectedException{
+        try {
+            repository.save(truncatedObject);
+        } catch (DataIntegrityViolationException e1) {
+            throw new UnexpectedException(Messages.Exception.DATABASE_INTEGRITY_VIOLATED, e1);
         }
     }
 


### PR DESCRIPTION
A DataIntegrityViolationException was been raised when something unexpected happened in the db schema. I've catched this exception and raised an UnexpectedException with a more readable message to the user.