### PR TITLE
Improve authorization structure

### DIFF
--- a/src/main/java/cloud/fogbow/common/models/FogbowOperation.java
+++ b/src/main/java/cloud/fogbow/common/models/FogbowOperation.java
@@ -1,0 +1,5 @@
+package cloud.fogbow.common.models;
+
+public class FogbowOperation {
+
+}

--- a/src/main/java/cloud/fogbow/common/plugins/authorization/AuthorizationPlugin.java
+++ b/src/main/java/cloud/fogbow/common/plugins/authorization/AuthorizationPlugin.java
@@ -2,9 +2,10 @@ package cloud.fogbow.common.plugins.authorization;
 
 import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.FogbowOperation;
 import cloud.fogbow.common.models.SystemUser;
 
-public interface AuthorizationPlugin {
+public interface AuthorizationPlugin<T extends FogbowOperation> {
     /**
      * Verifies if the user represented by the systemUser object is authorized to perform the operation on the
      * type of resource indicated, in the cloud indicated.
@@ -31,4 +32,6 @@ public interface AuthorizationPlugin {
      */
     public boolean isAuthorized(SystemUser systemUser, String operation, String target)
             throws UnauthorizedRequestException, UnexpectedException;
+
+    public boolean isAuthorized(SystemUser systemUser, T operation) throws UnauthorizedRequestException, UnexpectedException;
 }

--- a/src/main/java/cloud/fogbow/common/plugins/authorization/ComposedAuthorizationPlugin.java
+++ b/src/main/java/cloud/fogbow/common/plugins/authorization/ComposedAuthorizationPlugin.java
@@ -4,6 +4,7 @@ import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
 import cloud.fogbow.common.constants.Messages;
 import cloud.fogbow.common.exceptions.FatalErrorException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.FogbowOperation;
 import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.util.ClassFactory;
 
@@ -74,5 +75,10 @@ public class ComposedAuthorizationPlugin implements AuthorizationPlugin {
             authorizationPlugins.add(i, (AuthorizationPlugin) classFactory.createPluginInstance(pluginNames.get(i)));
         }
         return authorizationPlugins;
+    }
+
+    @Override
+    public boolean isAuthorized(SystemUser systemUser, FogbowOperation operation) {
+        return true;
     }
 }

--- a/src/main/java/cloud/fogbow/common/plugins/authorization/DefaultAuthorizationPlugin.java
+++ b/src/main/java/cloud/fogbow/common/plugins/authorization/DefaultAuthorizationPlugin.java
@@ -2,6 +2,7 @@ package cloud.fogbow.common.plugins.authorization;
 
 import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
 import cloud.fogbow.common.exceptions.UnexpectedException;
+import cloud.fogbow.common.models.FogbowOperation;
 import cloud.fogbow.common.models.SystemUser;
 
 public class DefaultAuthorizationPlugin implements AuthorizationPlugin {
@@ -18,6 +19,11 @@ public class DefaultAuthorizationPlugin implements AuthorizationPlugin {
     @Override
     public boolean isAuthorized(SystemUser systemUserToken, String operation, String type)
             throws UnauthorizedRequestException, UnexpectedException {
+        return true;
+    }
+
+    @Override
+    public boolean isAuthorized(SystemUser systemUser, FogbowOperation operation) {
         return true;
     }
 }


### PR DESCRIPTION
The way that the authorization was implemented was forcing each service to create a method in the AuthPlugin with the parameters it needs. Now, all this params have been wrapped into operation, each service can create its own operation that must extends FogbowOperation, and thus the interface's method can be the same one for all services.