### PR TITLE
Adequate authentication plugin interface

### DIFF
--- a/src/main/java/cloud/fogbow/common/plugins/authorization/AuthorizationPlugin.java
+++ b/src/main/java/cloud/fogbow/common/plugins/authorization/AuthorizationPlugin.java
@@ -1,7 +1,6 @@
 package cloud.fogbow.common.plugins.authorization;
 
 import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
-import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.FogbowOperation;
 import cloud.fogbow.common.models.SystemUser;
 
@@ -15,5 +14,5 @@ public interface AuthorizationPlugin<T extends FogbowOperation> {
      * @param operation the Operation object describing the operation the user is requesting to perform
      * @return a boolean stating whether the user is authorized or not.
      */
-    public boolean isAuthorized(SystemUser systemUser, T operation) throws UnauthorizedRequestException, UnexpectedException;
+    public boolean isAuthorized(SystemUser systemUser, T operation) throws UnauthorizedRequestException;
 }

--- a/src/main/java/cloud/fogbow/common/plugins/authorization/ComposedAuthorizationPlugin.java
+++ b/src/main/java/cloud/fogbow/common/plugins/authorization/ComposedAuthorizationPlugin.java
@@ -3,7 +3,6 @@ package cloud.fogbow.common.plugins.authorization;
 import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
 import cloud.fogbow.common.constants.Messages;
 import cloud.fogbow.common.exceptions.FatalErrorException;
-import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.FogbowOperation;
 import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.util.ClassFactory;
@@ -24,7 +23,7 @@ public class ComposedAuthorizationPlugin<T extends FogbowOperation> implements A
 
     @Override
     public boolean isAuthorized(SystemUser systemUser, FogbowOperation operation)
-            throws UnauthorizedRequestException, UnexpectedException {
+            throws UnauthorizedRequestException {
 
         for (AuthorizationPlugin plugin : this.authorizationPlugins) {
             if (!plugin.isAuthorized(systemUser, operation)) {

--- a/src/main/java/cloud/fogbow/common/plugins/authorization/DistributedAuthorizationPluginClient.java
+++ b/src/main/java/cloud/fogbow/common/plugins/authorization/DistributedAuthorizationPluginClient.java
@@ -1,7 +1,6 @@
 package cloud.fogbow.common.plugins.authorization;
 
 import cloud.fogbow.common.exceptions.UnauthorizedRequestException;
-import cloud.fogbow.common.exceptions.UnexpectedException;
 import cloud.fogbow.common.models.RestfulFogbowOperation;
 import cloud.fogbow.common.models.SystemUser;
 
@@ -19,7 +18,7 @@ public abstract class DistributedAuthorizationPluginClient implements Authorizat
     }
 
     @Override
-    public boolean isAuthorized(SystemUser systemUserToken, RestfulFogbowOperation operation) throws UnexpectedException, UnauthorizedRequestException {
+    public boolean isAuthorized(SystemUser systemUserToken, RestfulFogbowOperation operation) throws UnauthorizedRequestException {
         String endpoint = operation.getEndpoint();
         StringBuffer content = null;
 


### PR DESCRIPTION
## Description
Changed the exceptions thrown by the isAuthorized() method of the authentication plugin

## Proposed changes
Authentication plugin method isAuthorized() should throw only the UnathorizedRequestException.

## Additional information
This PR is related to PR #475 of the RAS service

## Reminding
