### PR TITLE
Add BinaryUnit class with byte conversion methods

### DIFF
--- a/src/main/java/cloud/fogbow/common/util/BinaryUnit.java
+++ b/src/main/java/cloud/fogbow/common/util/BinaryUnit.java
@@ -1,0 +1,63 @@
+package cloud.fogbow.common.util;
+
+public class BinaryUnit {
+
+    private static final long BINARY_BASE_UNIT = 1024;
+
+    public static Byte bytes(double value) { return new Byte(value); }
+    public static Kilobyte kilobytes(double value) { return new Kilobyte(value); }
+    public static Megabyte megabytes(double value) {
+        return new Megabyte(value);
+    }
+    public static Gigabyte gigabytes(double value) {
+        return new Gigabyte(value);
+    }
+
+    public static class Byte {
+        private double value;
+        private Byte(double value) {
+            this.value = value;
+        }
+        public double asKilobytes() { return value / Math.pow(BINARY_BASE_UNIT, 1); }
+        public double asMegabytes() {
+            return value / Math.pow(BINARY_BASE_UNIT, 2);
+        }
+        public double asGigabytes() {
+            return value / Math.pow(BINARY_BASE_UNIT, 3);
+        }
+    }
+
+    public static class Kilobyte {
+        private double value;
+        private Kilobyte(double value) { this.value = value; }
+        public double asBytes() { return value * Math.pow(BINARY_BASE_UNIT, 1); }
+        public double asMegabytes() {
+            return value / Math.pow(BINARY_BASE_UNIT, 1);
+        }
+        public double asGigabytes() {
+            return value / Math.pow(BINARY_BASE_UNIT, 2);
+        }
+    }
+
+    public static class Megabyte {
+        private double value;
+        private Megabyte(double value) {
+            this.value = value;
+        }
+        public double asBytes() { return value * Math.pow(BINARY_BASE_UNIT, 2); }
+        public double asKilobytes() { return value * Math.pow(BINARY_BASE_UNIT, 1); }
+        public double asGigabytes() {
+            return value / Math.pow(BINARY_BASE_UNIT, 1);
+        }
+    }
+
+    public static class Gigabyte {
+        private double value;
+        private Gigabyte(double value) {
+            this.value = value;
+        }
+        public double asBytes() { return value * Math.pow(BINARY_BASE_UNIT, 3); }
+        public double asKilobytes() { return value * Math.pow(BINARY_BASE_UNIT, 2); }
+        public double asMegabytes() { return value * Math.pow(BINARY_BASE_UNIT, 1); }
+    }
+}

--- a/src/test/java/cloud/fogbow/common/util/BinaryUnitTest.java
+++ b/src/test/java/cloud/fogbow/common/util/BinaryUnitTest.java
@@ -1,0 +1,360 @@
+package cloud.fogbow.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BinaryUnitTest {
+    @Test
+    public void testByteToKilobyte() {
+        // set up
+        double expected1 = 0.5;
+        double expected2 = 1;
+        double expected3 = 1.5;
+        double expected4 = 2;
+
+        int ONE_KILOBYTE = 1024;
+        double value1 = 0.5 * ONE_KILOBYTE;
+        double value2 = 1 * ONE_KILOBYTE;
+        double value3 = 1.5 * ONE_KILOBYTE;
+        double value4 = 2 * ONE_KILOBYTE;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.bytes(value1).asKilobytes();
+        double result2 = BinaryUnit.bytes(value2).asKilobytes();
+        double result3 = BinaryUnit.bytes(value3).asKilobytes();
+        double result4 = BinaryUnit.bytes(value4).asKilobytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testByteToMegabyte() {
+        // set up
+        double expected1 = 0.5;
+        double expected2 = 1;
+        double expected3 = 1.5;
+        double expected4 = 2;
+
+        double ONE_MEGABYTE = Math.pow(1024, 2);
+        double value1 = 0.5 * ONE_MEGABYTE;
+        double value2 = 1 * ONE_MEGABYTE;
+        double value3 = 1.5 * ONE_MEGABYTE;
+        double value4 = 2 * ONE_MEGABYTE;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.bytes(value1).asMegabytes();
+        double result2 = BinaryUnit.bytes(value2).asMegabytes();
+        double result3 = BinaryUnit.bytes(value3).asMegabytes();
+        double result4 = BinaryUnit.bytes(value4).asMegabytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testByteToGigabyte() {
+        // set up
+        double expected1 = 0.5;
+        double expected2 = 1;
+        double expected3 = 1.5;
+        double expected4 = 2;
+
+        double ONE_GIGABYTE = Math.pow(1024, 3);
+        double value1 = 0.5 * ONE_GIGABYTE;
+        double value2 = 1 * ONE_GIGABYTE;
+        double value3 = 1.5 * ONE_GIGABYTE;
+        double value4 = 2 * ONE_GIGABYTE;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.bytes(value1).asGigabytes();
+        double result2 = BinaryUnit.bytes(value2).asGigabytes();
+        double result3 = BinaryUnit.bytes(value3).asGigabytes();
+        double result4 = BinaryUnit.bytes(value4).asGigabytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testKilobyteToByte() {
+        // set up
+        double expected1 = 512;
+        double expected2 = 1024;
+        double expected3 = 1024 + 512;
+        double expected4 = 2048;
+
+        double value1 = 0.5;
+        double value2 = 1;
+        double value3 = 1.5;
+        double value4 = 2;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.kilobytes(value1).asBytes();
+        double result2 = BinaryUnit.kilobytes(value2).asBytes();
+        double result3 = BinaryUnit.kilobytes(value3).asBytes();
+        double result4 = BinaryUnit.kilobytes(value4).asBytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testKilobyteToMegabyte() {
+        // set up
+        double ONE_MEGABYTE = Math.pow(1024, 1);
+
+        double expected1 = 0.5;
+        double expected2 = 1;
+        double expected3 = 1.5;
+        double expected4 = 2;
+
+        double value1 = 0.5 * ONE_MEGABYTE;
+        double value2 = 1 * ONE_MEGABYTE;
+        double value3 = 1.5 * ONE_MEGABYTE;
+        double value4 = 2 * ONE_MEGABYTE;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.kilobytes(value1).asMegabytes();
+        double result2 = BinaryUnit.kilobytes(value2).asMegabytes();
+        double result3 = BinaryUnit.kilobytes(value3).asMegabytes();
+        double result4 = BinaryUnit.kilobytes(value4).asMegabytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testKilobyteToGigabyte() {
+        // set up
+        double expected1 = 0.5;
+        double expected2 = 1;
+        double expected3 = 1.5;
+        double expected4 = 2;
+
+        double ONE_GIGABYTE = Math.pow(1024, 2);
+        double value1 = 0.5 * ONE_GIGABYTE;
+        double value2 = 1 * ONE_GIGABYTE;
+        double value3 = 1.5 * ONE_GIGABYTE;
+        double value4 = 2 * ONE_GIGABYTE;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.kilobytes(value1).asGigabytes();
+        double result2 = BinaryUnit.kilobytes(value2).asGigabytes();
+        double result3 = BinaryUnit.kilobytes(value3).asGigabytes();
+        double result4 = BinaryUnit.kilobytes(value4).asGigabytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testMegabyteToByte() {
+        // set up
+        double ONE_MEGABYTE = Math.pow(1024, 2);
+
+        double expected1 = 0.5 * ONE_MEGABYTE;
+        double expected2 = ONE_MEGABYTE;
+        double expected3 = 1.5 * ONE_MEGABYTE;
+        double expected4 = 2 * ONE_MEGABYTE;
+
+        double value1 = 0.5;
+        double value2 = 1;
+        double value3 = 1.5;
+        double value4 = 2;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.megabytes(value1).asBytes();
+        double result2 = BinaryUnit.megabytes(value2).asBytes();
+        double result3 = BinaryUnit.megabytes(value3).asBytes();
+        double result4 = BinaryUnit.megabytes(value4).asBytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testMegabyteToKilobyte() {
+        // set up
+        double ONE_MEGABYTE = Math.pow(1024, 1);
+
+        double expected1 = 0.5 * ONE_MEGABYTE;
+        double expected2 = 1 * ONE_MEGABYTE;
+        double expected3 = 1.5 * ONE_MEGABYTE;
+        double expected4 = 2 * ONE_MEGABYTE;
+
+        double value1 = 0.5;
+        double value2 = 1;
+        double value3 = 1.5;
+        double value4 = 2;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.megabytes(value1).asKilobytes();
+        double result2 = BinaryUnit.megabytes(value2).asKilobytes();
+        double result3 = BinaryUnit.megabytes(value3).asKilobytes();
+        double result4 = BinaryUnit.megabytes(value4).asKilobytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testMegabyteToGigabyte() {
+        // set up
+        double ONE_MEGABYTE = Math.pow(1024, 1);
+
+        double expected1 = 0.5;
+        double expected2 = 1;
+        double expected3 = 1.5;
+        double expected4 = 2;
+
+        double value1 = 0.5 * ONE_MEGABYTE;
+        double value2 = 1 * ONE_MEGABYTE;
+        double value3 = 1.5 * ONE_MEGABYTE;
+        double value4 = 2 * ONE_MEGABYTE;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.megabytes(value1).asGigabytes();
+        double result2 = BinaryUnit.megabytes(value2).asGigabytes();
+        double result3 = BinaryUnit.megabytes(value3).asGigabytes();
+        double result4 = BinaryUnit.megabytes(value4).asGigabytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testGigabyteToByte() {
+        // set up
+        double ONE_GIGABYTE = Math.pow(1024, 3);
+
+        double expected1 = 0.5 * ONE_GIGABYTE;
+        double expected2 = ONE_GIGABYTE;
+        double expected3 = 1.5 * ONE_GIGABYTE;
+        double expected4 = 2 * ONE_GIGABYTE;
+
+        double value1 = 0.5;
+        double value2 = 1;
+        double value3 = 1.5;
+        double value4 = 2;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.gigabytes(value1).asBytes();
+        double result2 = BinaryUnit.gigabytes(value2).asBytes();
+        double result3 = BinaryUnit.gigabytes(value3).asBytes();
+        double result4 = BinaryUnit.gigabytes(value4).asBytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testGigabyteToKilobyte() {
+        // set up
+        double ONE_GIGABYTE = Math.pow(1024, 2);
+
+        double expected1 = 0.5 * ONE_GIGABYTE;
+        double expected2 = ONE_GIGABYTE;
+        double expected3 = 1.5 * ONE_GIGABYTE;
+        double expected4 = 2 * ONE_GIGABYTE;
+
+        double value1 = 0.5;
+        double value2 = 1;
+        double value3 = 1.5;
+        double value4 = 2;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.gigabytes(value1).asKilobytes();
+        double result2 = BinaryUnit.gigabytes(value2).asKilobytes();
+        double result3 = BinaryUnit.gigabytes(value3).asKilobytes();
+        double result4 = BinaryUnit.gigabytes(value4).asKilobytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+
+    @Test
+    public void testGigabyteToMegabyte() {
+        // set up
+        double ONE_GIGABYTE = Math.pow(1024, 1);
+
+        double expected1 = 0.5 * ONE_GIGABYTE;
+        double expected2 = ONE_GIGABYTE;
+        double expected3 = 1.5 * ONE_GIGABYTE;
+        double expected4 = 2 * ONE_GIGABYTE;
+
+        double value1 = 0.5;
+        double value2 = 1;
+        double value3 = 1.5;
+        double value4 = 2;
+
+        double delta = 0;
+
+        // exercise
+        double result1 = BinaryUnit.gigabytes(value1).asMegabytes();
+        double result2 = BinaryUnit.gigabytes(value2).asMegabytes();
+        double result3 = BinaryUnit.gigabytes(value3).asMegabytes();
+        double result4 = BinaryUnit.gigabytes(value4).asMegabytes();
+
+        // verify
+        Assert.assertEquals(expected1, result1, delta);
+        Assert.assertEquals(expected2, result2, delta);
+        Assert.assertEquals(expected3, result3, delta);
+        Assert.assertEquals(expected4, result4, delta);
+    }
+}


### PR DESCRIPTION
This pull request implements a class with byte conversion for other services usage. 

**A example usage of this class Converting GB to KB:**

```java
double sizeInGB = 1;
double sizeInKB = BinaryUnit.gigabytes(sizeInGB).asKilobytes();
```

**Conversions implemented:**
- Byte to KB
- Byte to MB
- Byte to GB
- KB to Byte
- KB to MB
- KB to GB
- MB to Byte
- MB to KB
- MB to GB
- GB to Byte
- GB to KB
- GB to MB