### PR TITLE
Google cloud http client

### DIFF
--- a/src/main/java/cloud/fogbow/common/constants/GoogleCloudConstants.java
+++ b/src/main/java/cloud/fogbow/common/constants/GoogleCloudConstants.java
@@ -1,0 +1,6 @@
+package cloud.fogbow.common.constants;
+
+public class GoogleCloudConstants {
+    public static final String AUTHORIZATION_KEY = "Authorization";
+    public static final String BEARER_S = "Bearer %s";
+}

--- a/src/main/java/cloud/fogbow/common/models/GoogleCloudUser.java
+++ b/src/main/java/cloud/fogbow/common/models/GoogleCloudUser.java
@@ -1,0 +1,7 @@
+package cloud.fogbow.common.models;
+
+public class GoogleCloudUser extends CloudUser {
+    public GoogleCloudUser(String userId, String userName, String token) {
+        super(userId, userName, token);
+    }
+}

--- a/src/main/java/cloud/fogbow/common/util/connectivity/cloud/googlecloud/GoogleCloudHttpClient.java
+++ b/src/main/java/cloud/fogbow/common/util/connectivity/cloud/googlecloud/GoogleCloudHttpClient.java
@@ -1,0 +1,33 @@
+package cloud.fogbow.common.util.connectivity.cloud.googlecloud;
+
+import cloud.fogbow.common.constants.GoogleCloudConstants;
+import cloud.fogbow.common.constants.HttpConstants;
+import cloud.fogbow.common.constants.HttpMethod;
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.models.GoogleCloudUser;
+import cloud.fogbow.common.util.connectivity.HttpRequest;
+import cloud.fogbow.common.util.connectivity.cloud.CloudHttpClient;
+
+import java.util.Map;
+
+public class GoogleCloudHttpClient extends CloudHttpClient<GoogleCloudUser> {
+    @Override
+    public HttpRequest prepareRequest(HttpRequest genericRequest, GoogleCloudUser cloudUser) throws FogbowException {
+        HttpRequest clonedRequest = new HttpRequest(
+                genericRequest.getMethod(), genericRequest.getUrl(), genericRequest.getBody(), genericRequest.getHeaders());
+
+        String token = cloudUser.getToken();
+
+        Map<String, String> headers = clonedRequest.getHeaders();
+        String bearerToken = String.format(GoogleCloudConstants.BEARER_S, token);
+        headers.put(GoogleCloudConstants.AUTHORIZATION_KEY, bearerToken);
+
+        if (genericRequest.getMethod().equals(HttpMethod.GET)
+                || genericRequest.getMethod().equals(HttpMethod.POST)) {
+            headers.put(HttpConstants.CONTENT_TYPE_KEY, HttpConstants.JSON_CONTENT_TYPE_KEY);
+            headers.put(HttpConstants.ACCEPT_KEY, HttpConstants.JSON_CONTENT_TYPE_KEY);
+        }
+
+        return clonedRequest;
+    }
+}

--- a/src/test/java/cloud/fogbow/common/util/connectivity/cloud/googlecloud/GoogleCloudHttpClientTest.java
+++ b/src/test/java/cloud/fogbow/common/util/connectivity/cloud/googlecloud/GoogleCloudHttpClientTest.java
@@ -1,0 +1,95 @@
+package cloud.fogbow.common.util.connectivity.cloud.googlecloud;
+
+import cloud.fogbow.common.constants.GoogleCloudConstants;
+import cloud.fogbow.common.constants.HttpConstants;
+import cloud.fogbow.common.constants.HttpMethod;
+import cloud.fogbow.common.exceptions.FogbowException;
+import cloud.fogbow.common.models.GoogleCloudUser;
+import cloud.fogbow.common.util.connectivity.HttpRequest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class GoogleCloudHttpClientTest {
+    private static final String TOKEN = "any-token";
+    private static final String ANY_URL = "any-url";
+
+    private GoogleCloudHttpClient client;
+    private GoogleCloudUser user;
+
+    @Before
+    public void setUp() {
+        this.client = new GoogleCloudHttpClient();
+        this.user = createUser();
+    }
+
+    private GoogleCloudUser createUser() {
+        GoogleCloudUser user = Mockito.mock(GoogleCloudUser.class);
+        Mockito.when(user.getToken()).thenReturn(TOKEN);
+        return user;
+    }
+
+    @Test
+    public void testPrepareRequestGET() throws FogbowException {
+        // set up
+        HttpRequest genericRequest = new HttpRequest(
+                HttpMethod.GET,
+                ANY_URL,
+                new HashMap<>(),
+                new HashMap<>()
+        );
+
+        // exercise
+        HttpRequest preparedRequest = this.client.prepareRequest(genericRequest, this.user);
+
+        // verify
+        Assert.assertEquals(HttpMethod.GET, preparedRequest.getMethod());
+        Assert.assertEquals(ANY_URL, preparedRequest.getUrl());
+
+        Map<String, String> headers = preparedRequest.getHeaders();
+        Assert.assertTrue(headers.containsKey(GoogleCloudConstants.AUTHORIZATION_KEY));
+        Assert.assertTrue(headers.containsKey(HttpConstants.ACCEPT_KEY));
+        Assert.assertTrue(headers.containsKey(HttpConstants.CONTENT_TYPE_KEY));
+
+        String expectedBearerToken = String.format(GoogleCloudConstants.BEARER_S, TOKEN);
+        Assert.assertEquals(expectedBearerToken, headers.get(GoogleCloudConstants.AUTHORIZATION_KEY));
+
+        String jsonContentType = HttpConstants.JSON_CONTENT_TYPE_KEY;
+        Assert.assertEquals(jsonContentType, headers.get(HttpConstants.ACCEPT_KEY));
+        Assert.assertEquals(jsonContentType, headers.get(HttpConstants.CONTENT_TYPE_KEY));
+    }
+
+    @Test
+    public void testPrepareRequestPOST() throws FogbowException {
+        // set up
+        HttpRequest genericRequest = new HttpRequest(
+                HttpMethod.POST,
+                ANY_URL,
+                new HashMap<>(),
+                new HashMap<>()
+        );
+
+        // exercise
+        HttpRequest preparedRequest = this.client.prepareRequest(genericRequest, this.user);
+
+        // verify
+        Assert.assertEquals(HttpMethod.POST, preparedRequest.getMethod());
+        Assert.assertEquals(ANY_URL, preparedRequest.getUrl());
+
+        Map<String, String> headers = preparedRequest.getHeaders();
+        Assert.assertTrue(headers.containsKey(GoogleCloudConstants.AUTHORIZATION_KEY));
+        Assert.assertTrue(headers.containsKey(HttpConstants.ACCEPT_KEY));
+        Assert.assertTrue(headers.containsKey(HttpConstants.CONTENT_TYPE_KEY));
+
+        String expectedBearerToken = String.format(GoogleCloudConstants.BEARER_S, TOKEN);
+        Assert.assertEquals(expectedBearerToken, headers.get(GoogleCloudConstants.AUTHORIZATION_KEY));
+
+        String jsonContentType = HttpConstants.JSON_CONTENT_TYPE_KEY;
+        Assert.assertEquals(jsonContentType, headers.get(HttpConstants.ACCEPT_KEY));
+        Assert.assertEquals(jsonContentType, headers.get(HttpConstants.CONTENT_TYPE_KEY));
+    }
+}


### PR DESCRIPTION
This pull request implements the GoogleCloudHttpClient class. It will be used to make HTTP requests to the Google Cloud REST API.