### PR TITLE
Modified ComposedAuthorizationPlugin to use a custom ClassFactory

### DIFF
--- a/src/main/java/cloud/fogbow/common/plugins/authorization/ComposedAuthorizationPlugin.java
+++ b/src/main/java/cloud/fogbow/common/plugins/authorization/ComposedAuthorizationPlugin.java
@@ -6,6 +6,8 @@ import cloud.fogbow.common.exceptions.FatalErrorException;
 import cloud.fogbow.common.models.FogbowOperation;
 import cloud.fogbow.common.models.SystemUser;
 import cloud.fogbow.common.util.ClassFactory;
+import cloud.fogbow.common.util.CommonClassFactory;
+import cloud.fogbow.common.util.HomeDir;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -16,7 +18,16 @@ import java.util.Scanner;
 public class ComposedAuthorizationPlugin<T extends FogbowOperation> implements AuthorizationPlugin<T> {
     List<AuthorizationPlugin<T>> authorizationPlugins;
 
+    private static final String DEFAULT_CONF_FILE_NAME = "composed_auth.conf";
+    private String confPath;
+    private ClassFactory classFactory;
+    
+    public ComposedAuthorizationPlugin() {
+    	
+    }
+    
     public ComposedAuthorizationPlugin(String confPath) {
+    	this.classFactory = new CommonClassFactory();
         List<String> pluginNames = getPluginNames(confPath);
         this.authorizationPlugins = getPlugins(pluginNames);
     }
@@ -56,11 +67,18 @@ public class ComposedAuthorizationPlugin<T extends FogbowOperation> implements A
     }
 
     private List<AuthorizationPlugin<T>> getPlugins(List<String> pluginNames) {
-        ClassFactory classFactory = new ClassFactory();
         ArrayList<AuthorizationPlugin<T>> authorizationPlugins = new ArrayList<>();
         for (int i = 0; i < pluginNames.size(); i++) {
-            authorizationPlugins.add(i, (AuthorizationPlugin<T>) classFactory.createPluginInstance(pluginNames.get(i)));
+            authorizationPlugins.add(i, (AuthorizationPlugin<T>) this.classFactory.createPluginInstance(pluginNames.get(i)));
         }
         return authorizationPlugins;
+    }
+
+    public void startPlugin(ClassFactory classFactory) {
+    	this.classFactory = classFactory;
+        String path = HomeDir.getPath();
+        this.confPath = path + DEFAULT_CONF_FILE_NAME;
+        List<String> pluginNames = getPluginNames(confPath);
+        this.authorizationPlugins = getPlugins(pluginNames);
     }
 }

--- a/src/main/java/cloud/fogbow/common/util/ClassFactory.java
+++ b/src/main/java/cloud/fogbow/common/util/ClassFactory.java
@@ -1,36 +1,7 @@
 package cloud.fogbow.common.util;
 
-import cloud.fogbow.common.constants.Messages;
 import cloud.fogbow.common.exceptions.FatalErrorException;
 
-import java.lang.reflect.Constructor;
-import java.util.Arrays;
-
-// Each package has to have its own ClassFactory
-
-public class ClassFactory {
-
-    public Object createPluginInstance(String pluginClassName, String ... params) throws FatalErrorException {
-
-        Object pluginInstance;
-        Constructor<?> constructor;
-
-        try {
-            Class<?> classpath = Class.forName(pluginClassName);
-            if (params.length > 0) {
-                Class<String>[] constructorArgTypes = new Class[params.length];
-                Arrays.fill(constructorArgTypes, String.class);
-                constructor = classpath.getConstructor(constructorArgTypes);
-            } else {
-                constructor = classpath.getConstructor();
-            }
-
-            pluginInstance = constructor.newInstance(params);
-        } catch (ClassNotFoundException e) {
-            throw new FatalErrorException(String.format(Messages.Exception.UNABLE_TO_FIND_CLASS_S, pluginClassName));
-        } catch (Exception e) {
-            throw new FatalErrorException(e.getMessage(), e);
-        }
-        return pluginInstance;
-    }
+public interface ClassFactory {
+	Object createPluginInstance(String pluginClassName, String ... params) throws FatalErrorException;
 }

--- a/src/main/java/cloud/fogbow/common/util/CommonClassFactory.java
+++ b/src/main/java/cloud/fogbow/common/util/CommonClassFactory.java
@@ -1,0 +1,36 @@
+package cloud.fogbow.common.util;
+
+import cloud.fogbow.common.constants.Messages;
+import cloud.fogbow.common.exceptions.FatalErrorException;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+
+// Each package has to have its own ClassFactory
+
+public class CommonClassFactory implements ClassFactory {
+
+    public Object createPluginInstance(String pluginClassName, String ... params) throws FatalErrorException {
+
+        Object pluginInstance;
+        Constructor<?> constructor;
+
+        try {
+            Class<?> classpath = Class.forName(pluginClassName);
+            if (params.length > 0) {
+                Class<String>[] constructorArgTypes = new Class[params.length];
+                Arrays.fill(constructorArgTypes, String.class);
+                constructor = classpath.getConstructor(constructorArgTypes);
+            } else {
+                constructor = classpath.getConstructor();
+            }
+
+            pluginInstance = constructor.newInstance(params);
+        } catch (ClassNotFoundException e) {
+            throw new FatalErrorException(String.format(Messages.Exception.UNABLE_TO_FIND_CLASS_S, pluginClassName));
+        } catch (Exception e) {
+            throw new FatalErrorException(e.getMessage(), e);
+        }
+        return pluginInstance;
+    }
+}

--- a/src/test/java/cloud/fogbow/common/util/ClassFactoryTest.java
+++ b/src/test/java/cloud/fogbow/common/util/ClassFactoryTest.java
@@ -14,11 +14,11 @@ public class ClassFactoryTest {
 	private static final String TWO_PARAMETER = "parameter2";
 	private static final String STUB_CLASSNAME = "cloud.fogbow.common.util.stubs.StubClassForFactory";
 
-	private ClassFactory classFactory;
+	private CommonClassFactory classFactory;
 
 	@Before
 	public void setUp() {
-		this.classFactory = new ClassFactory();
+		this.classFactory = new CommonClassFactory();
 	}
 
 	// test case: When invoking the createPluginInstance method without parameters


### PR DESCRIPTION
This PR fixes the issue on using ComposedAuthorizationPlugin in RAS. This fix consists on allowing the ComposedAuthorizationPlugin to use a ClassFactory created by RAS, passed as argument to the startPlugin method, which is responsible for starting the other sub-plugins.