### PR TITLE
Adding Exception type to represent communication errors between providers

### DIFF
--- a/src/main/java/cloud/fogbow/common/exceptions/CommunicationErrorException.java
+++ b/src/main/java/cloud/fogbow/common/exceptions/CommunicationErrorException.java
@@ -1,0 +1,11 @@
+package cloud.fogbow.common.exceptions;
+
+public class CommunicationErrorException extends FogbowException {
+
+	private static final long serialVersionUID = 1L;
+
+	public CommunicationErrorException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/cloud/fogbow/common/http/FogbowExceptionToHttpErrorConditionTranslator.java
+++ b/src/main/java/cloud/fogbow/common/http/FogbowExceptionToHttpErrorConditionTranslator.java
@@ -71,6 +71,13 @@ public class FogbowExceptionToHttpErrorConditionTranslator extends ResponseEntit
         return new ResponseEntity<>(errorDetails, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    @ExceptionHandler(CommunicationErrorException.class)
+    public final ResponseEntity<ExceptionResponse> handleCommunicationErrorException(Exception ex, WebRequest request) {
+
+        ExceptionResponse errorDetails = new ExceptionResponse(ex.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(errorDetails, HttpStatus.BAD_GATEWAY);
+    }
+    
     /*
     It should never happen because any Exception must be mapped to one of the above FogbowException extensions.
      */


### PR DESCRIPTION
This PR adds a new Exception type used by RAS to represent communication errors between providers. It also adds a translation rule "Exception type to HTTP status code" for this new Exception.