### PR TITLE
Fix DefaultLaunchCommandGeneratorTest on RAS

### DIFF
--- a/src/main/java/cloud/fogbow/common/util/CloudInitUserDataBuilder.java
+++ b/src/main/java/cloud/fogbow/common/util/CloudInitUserDataBuilder.java
@@ -386,12 +386,20 @@ public class CloudInitUserDataBuilder {
     public String buildUserData() throws InternalServerErrorException {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            this.userDataMimeMessage.writeTo(baos);
-            return new String(baos.toByteArray(), this.charset);
-
+            
+            if (!userDataMimeMessageIsEmpty()) {
+                this.userDataMimeMessage.writeTo(baos);
+                return new String(baos.toByteArray(), this.charset);
+            }
+            
+            return "";
         } catch (MessagingException | IOException e) {
             throw new InternalServerErrorException(e.getMessage());
         }
+    }
+    
+    private boolean userDataMimeMessageIsEmpty() throws MessagingException {
+        return this.userDataMultipart.getCount() == 0;
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue with two test cases in DefaultLaunchCommandGeneratorTest class, in RAS.

The tests check the behavior of the method buildUserData when the user content is null. In this case, the MimeMessage used by CloudInitUserDataBuilder is never updated and, therefore, is empty. Thus, the call to MimeMessage.writeTo, used to export the user data, throws an exception.